### PR TITLE
Support build automation

### DIFF
--- a/config/war.js
+++ b/config/war.js
@@ -5,7 +5,7 @@ module.exports = {
 
   dev: {
     options: {
-      war_name: '<%= pkg.name %>-<%= pkg.version %>-BUILD'
+      war_name: '<%= pkg.name %>-<%= pkg.version %>-BUILD<%= ci.warNameSuffix %>'
     },
     files: [
       {

--- a/index.js
+++ b/index.js
@@ -83,8 +83,8 @@ grunt.initConfig({
     buildId: process.env.BUILD_ID || 0,
     buildUrl: process.env.BUILD_URL || "",
     buildTag: process.env.BUILD_TAG || "",
-    // Use short hash
-    buildCommit: (process.env.GIT_COMMIT !== "" && process.env.GIT_COMMIT !== undefined) ? process.env.GIT_COMMIT.substring(0, 7) : "",
+    buildCommit: (process.env.GIT_COMMIT !== "" && process.env.GIT_COMMIT !== undefined) ? process.env.GIT_COMMIT : "",
+    buildCommitShort: (process.env.GIT_COMMIT !== "" && process.env.GIT_COMMIT !== undefined) ? process.env.GIT_COMMIT.substring(0, 7) : "",
     warNameSuffix: (process.env.BUILD_NUMBER !== undefined) ? "-" + process.env.BUILD_NUMBER : ""
   },
   pkg: projPkg,
@@ -113,12 +113,14 @@ grunt.registerTask('build', [
   'compile',
   'copy:dev',
   (Array.isArray(projPkg.buildCopy) ? 'copyExtras' : 'noop'),
+  'manifest',
   'war:dev'
 ])
 grunt.registerTask('buildprod', [
   'compile',
   'copy:prod',
   (Array.isArray(projPkg.buildCopy) ? 'copyExtras' : 'noop'),
+  'manifest',
   'war:prod'
 ])
 

--- a/index.js
+++ b/index.js
@@ -78,6 +78,15 @@ var reqTask = function (task) {
 
 var projPkg = grunt.file.readJSON('package.json')
 grunt.initConfig({
+  ci: {
+    buildNumber: process.env.BUILD_NUMBER || 0,
+    buildId: process.env.BUILD_ID || 0,
+    buildUrl: process.env.BUILD_URL || "",
+    buildTag: process.env.BUILD_TAG || "",
+    // Use short hash
+    buildCommit: (process.env.GIT_COMMIT !== "" && process.env.GIT_COMMIT !== undefined) ? process.env.GIT_COMMIT.substring(0, 7) : "",
+    warNameSuffix: (process.env.BUILD_NUMBER !== undefined) ? "-" + process.env.BUILD_NUMBER : ""
+  },
   pkg: projPkg,
   bump: reqConfig('bump'),
   clean: reqConfig('clean'),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qless/build-grunt",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Unified build module for QLess Grunt based projects",
   "main": "index.js",
   "scripts": {

--- a/tasks/manifest.js
+++ b/tasks/manifest.js
@@ -1,0 +1,13 @@
+module.exports = function (grunt) {
+  grunt.registerTask("manifest", "Create a detailed version manifest", function () {
+    var manifest = {
+      "id": grunt.config("pkg.name"),
+      "version": grunt.config("pkg.version"),
+      "build": grunt.config("ci.buildNumber"),
+      "commit": grunt.config("ci.buildCommit"),
+      "date": grunt.template.today("isoDateTime")
+    }
+
+    grunt.file.write('dist/version.json', JSON.stringify(manifest, "", 2))
+  })
+}


### PR DESCRIPTION
- Appends the build number, if it's present, to the WAR archive.
- Adds a new task, `manifest`, that creates a JSON document `version.json` with build metadata. The build metadata is relying on the Jenkins environment for the `build` and `commit` data; local builds won't have this information populated.