### PR TITLE
Use clearer version specifiers via pre-release labels

### DIFF
--- a/ci.js
+++ b/ci.js
@@ -1,0 +1,48 @@
+const ci = {
+  buildNumber: process.env.BUILD_NUMBER || 0,
+  buildId: process.env.BUILD_ID || 0,
+  buildBranch: process.env.BRANCH_NAME || "",
+  buildUrl: process.env.BUILD_URL || "",
+  buildTag: process.env.BUILD_TAG || "",
+  buildCommit:
+    process.env.GIT_COMMIT !== "" && process.env.GIT_COMMIT !== undefined
+      ? process.env.GIT_COMMIT
+      : "",
+  buildCommitShort:
+    process.env.GIT_COMMIT !== "" && process.env.GIT_COMMIT !== undefined
+      ? process.env.GIT_COMMIT.substring(0, 7)
+      : "",
+  username: process.env.USERNAME || "jenkins",
+  warNameSuffix:
+    process.env.BUILD_NUMBER !== undefined
+      ? "-" + process.env.BUILD_NUMBER
+      : "",
+  preReleaseLabel: function () {
+    const branch = this.buildBranch.toLowerCase();
+    const isLocal = !branch || !this.buildNumber;
+    
+    if (isLocal) {
+      // Developers won't usually set these environment variables; these are
+      // usually available when we run under Jenkins CI
+      return "-local";
+    }
+
+    const isReleaseCandidate =
+      (branch.indexOf("release/") || branch.indexOf("hotfix/")) &&
+      process.env.CHANGE_ID;
+    const isFeature = branch.indexOf("feature/") > -1;
+
+    if (isReleaseCandidate) {
+      return `-rc${this.buildNumber}`;
+    }
+
+    if (isFeature) {
+      const name = branch.split("/")[1];
+      return `-${name}.${this.buildNumber}.${this.buildCommitShort}`;
+    }
+
+    return ""
+  },
+};
+
+module.exports = ci;

--- a/config/uglify.js
+++ b/config/uglify.js
@@ -3,6 +3,8 @@ module.exports = {
     compress: true,
     mangle: true,
     report: 'min',
-    sourceMap: true
+    sourceMap: {
+      includeSources: true,
+    }
   }
 }

--- a/config/war.js
+++ b/config/war.js
@@ -5,7 +5,7 @@ module.exports = {
 
   dev: {
     options: {
-      war_name: '<%= pkg.name %>-<%= pkg.version %>-BUILD<%= ci.warNameSuffix %>'
+      war_name: '<%= pkg.name %>'
     },
     files: [
       {
@@ -19,7 +19,7 @@ module.exports = {
 
   prod: {
     options: {
-      war_name: '<%= pkg.name %>-<%= pkg.version %>'
+      war_name: '<%= pkg.name %>-<%= pkg.version %><%= ci.preReleaseLabel() %>'
     },
     files: [
       {

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 var path = require('path')
 var grunt = require('grunt')
 var pkg = require('./package.json')
+var ci = require('./ci')
 
 // Get the tasks passed in to the command
 var TasksArgs = process.argv.slice(2).filter(function (task) {
@@ -79,17 +80,7 @@ var reqTask = function (task) {
 
 var projPkg = grunt.file.readJSON('package.json')
 grunt.initConfig({
-  ci: {
-    buildNumber: process.env.BUILD_NUMBER || 0,
-    buildId: process.env.BUILD_ID || 0,
-    buildBranch: process.env.BRANCH_NAME || "",
-    buildUrl: process.env.BUILD_URL || "",
-    buildTag: process.env.BUILD_TAG || "",
-    buildCommit: (process.env.GIT_COMMIT !== "" && process.env.GIT_COMMIT !== undefined) ? process.env.GIT_COMMIT : "",
-    buildCommitShort: (process.env.GIT_COMMIT !== "" && process.env.GIT_COMMIT !== undefined) ? process.env.GIT_COMMIT.substring(0, 7) : "",
-    username: process.env.USERNAME || "jenkins",
-    warNameSuffix: (process.env.BUILD_NUMBER !== undefined) ? "-" + process.env.BUILD_NUMBER : ""
-  },
+  ci: ci,
   pkg: projPkg,
   bump: reqConfig('bump'),
   clean: reqConfig('clean'),


### PR DESCRIPTION
- Development builds do not include the version or a pre-release
  specifier no matter which branch is used.

  This reliably produces a local artifact with the filename `CEC.war`
  that Developers can sync without accouting for changes in the version
  #.

- Production builds include the version number, from package.json,
  and a pre-release specifier.

  - Production builds, produced outside of the CI environment, use the `local` label.

  - `master` produces the artifact named `CEC-[VERSION]`.

  - `release/` and `hotfix/` branches produce an artifact named `CEC-[VERSION]-rc[BUILD]`:
      - `[VERSION]` is the version from `package.json`.
      - `[BUILD]` is the incremental build # from the CI.

  - `feature/` branches produce an artifact named `CEC-[VERSION]-[BRANCH].[BUILD].[COMMIT_ID]`:
      - `[VERSION]` is the version from `package.json`.
      - `[BUILD]` is the incremental build # from the CI.
      - `[COMMIT_ID]` is the short commit id. This should provide
        a small measure of convenience when troubleshooting.

 