### PR TITLE
FIX: Release Candidate versions use `rc.[build]` not `rc[build]`

### DIFF
--- a/ci.js
+++ b/ci.js
@@ -42,7 +42,7 @@ const ci = {
     }
 
     if (isReleaseCandidate) {
-      return `-rc${this.buildNumber}`;
+      return `-rc.${this.buildNumber}`;
     }
 
     const name = branch.indexOf("/") !== -1 ? branch.split("/")[1] : branch;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qless/build-grunt",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Unified build module for QLess Grunt based projects",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This changes the pre-release label for Release Candidates to
`rc.[build]` rather than `rc[build]`